### PR TITLE
fix: truncate titles on android, change text, fix document styles

### DIFF
--- a/src/components/Document.tsx
+++ b/src/components/Document.tsx
@@ -39,35 +39,46 @@ const Document: FC<DocumentProps> = ({ item, isPlayerView = false }) => {
   }, [isPlayerView]);
 
   const classStyles = {
-    'ql-align-right': { textAlign: TEXT_ALIGNMENT.RIGHT },
-    'ql-align-center': { textAlign: TEXT_ALIGNMENT.CENTER },
-    'ql-align-left': { textAlign: TEXT_ALIGNMENT.LEFT },
-    'ql-align-justify': { textAlign: TEXT_ALIGNMENT.JUSTIFY },
+    'ql-align-right': {
+      textAlign: TEXT_ALIGNMENT.RIGHT,
+    },
+    'ql-align-center': {
+      textAlign: TEXT_ALIGNMENT.CENTER,
+    },
+    'ql-align-left': {
+      textAlign: TEXT_ALIGNMENT.LEFT,
+    },
+    'ql-align-justify': {
+      textAlign: TEXT_ALIGNMENT.JUSTIFY,
+    },
   };
+
+  const styles = StyleSheet.create({
+    container: {
+      width,
+      paddingHorizontal: 20,
+    },
+    headerButtons: {
+      flexDirection: 'row',
+    },
+  });
 
   return (
     <SafeAreaView edges={['left']}>
-      <View style={styles.container}>
-        <ScrollView>
+      <ScrollView>
+        <View style={styles.container}>
           <RenderHtml
+            tagsStyles={{
+              p: { marginBottom: 1 },
+            }}
             classesStyles={classStyles}
             contentWidth={width}
             source={{ html: item.extra.document?.content }}
           />
-        </ScrollView>
-      </View>
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    marginLeft: 20,
-    marginRight: 20,
-  },
-  headerButtons: {
-    flexDirection: 'row',
-  },
-});
 
 export default Document;

--- a/src/components/PlayerView.tsx
+++ b/src/components/PlayerView.tsx
@@ -64,13 +64,13 @@ const PlayerView: FC<PlayerViewProps> = ({ origin, children }) => {
 
 const styles = StyleSheet.create({
   topSpace: {
-    height: 20,
+    height: 10,
   },
   flatList: {
     height: '100%',
   },
   bottomSpace: {
-    height: 20,
+    height: 10,
   },
 });
 

--- a/src/components/common/ContainsOnlyFolderContent.tsx
+++ b/src/components/common/ContainsOnlyFolderContent.tsx
@@ -1,17 +1,28 @@
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { MaterialIcons } from '@expo/vector-icons';
 
+import { useRoute } from '@react-navigation/native';
+
+import { ItemScreenProps } from '../../navigation/types';
+
 const ContainsOnlyFolderContent = () => {
-  const { t } = useTranslation();
+  const route = useRoute<ItemScreenProps<'ItemStackPlayerFolder'>['route']>();
+  const { headerTitle } = route.params;
 
   return (
     <View style={styles.container}>
       <View style={styles.emptyIcon}>
         <MaterialIcons name="folder-copy" size={50} />
       </View>
-      <Text style={styles.text}>{t('FOLDER_CONTAINS_ONLY_FOLDERS')}</Text>
+      <Text style={styles.text}>
+        <Trans
+          i18nKey="FOLDER_CONTAINS_ONLY_FOLDERS" // optional -> fallbacks to defaults if not provided
+          values={{ title: headerTitle }}
+          components={{ b: <Text style={{ fontWeight: 'bold' }} /> }}
+        />
+      </Text>
     </View>
   );
 };

--- a/src/config/constants/constants.ts
+++ b/src/config/constants/constants.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { UUID } from '@graasp/sdk';
 
 export const APP_NAME = 'Graasp';
@@ -174,3 +176,13 @@ export const BOTTOM_SNAP_POINTS_SEARCH_FILTER = ['90%'];
 
 export const CHAT_MAX_LENGTH = 400;
 export const CHAT_WIDTH_IMAGE_MESSAGE = 0.65;
+
+// platform dependent value to allow correct automatic title truncation when defining headerRight in ItemStack
+// align center does not work well in android https://github.com/software-mansion/react-native-screens/issues/1573
+export const HEADER_TITLE_ALIGN_FOR_TRUNCATION: 'center' | 'left' =
+  Platform.select({
+    // width is acting weird with align left
+    ios: 'center',
+    // truncation does not work well with center align
+    android: 'left',
+  }) ?? 'center';

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -98,5 +98,5 @@
   "Open Map": "Open Map",
   "My Map": "My Map",
   "Show QR code": "Show QR code",
-  "FOLDER_CONTAINS_ONLY_FOLDERS": "This folder contains only folders.\nClick on the button below to navigate to the next content."
+  "FOLDER_CONTAINS_ONLY_FOLDERS": "{{title}} only contains folders.\nClick on the button below to navigate to the next content."
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -98,5 +98,5 @@
   "Open Map": "Ouvrir la Carte",
   "My Map": "Ma Carte",
   "Show QR code": "Montrer le code QR",
-  "FOLDER_CONTAINS_ONLY_FOLDERS": "Ce dossier ne contient que des dossiers.\nCliquez sur le bouton ci-dessous pour naviguer au contenu suivant."
+  "FOLDER_CONTAINS_ONLY_FOLDERS": "<b>{{title}}</b> ne contient que des dossiers.\nCliquez sur le bouton ci-dessous pour naviguer au contenu suivant."
 }

--- a/src/navigation/ItemStackNavigator.tsx
+++ b/src/navigation/ItemStackNavigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator } from '@react-navigation/stack';
 
+import { HEADER_TITLE_ALIGN_FOR_TRUNCATION } from '../config/constants/constants';
 import { defaultScreenOptions } from '../config/constants/navigation';
 import ChatScreen from '../screens/ChatScreen';
 import DetailsScreen from '../screens/DetailsScreen';
@@ -32,7 +33,7 @@ const ItemStackNavigator = () => {
         }}
         options={({ route: { params } }) => ({
           title: params?.headerTitle,
-          headerTitleAlign: 'center',
+          headerTitleAlign: HEADER_TITLE_ALIGN_FOR_TRUNCATION,
           // trick to force title ellipsis
           headerBackTitle: ' ',
         })}
@@ -45,7 +46,7 @@ const ItemStackNavigator = () => {
         }}
         options={({ route: { params } }) => ({
           title: params?.headerTitle,
-          headerTitleAlign: 'center',
+          headerTitleAlign: HEADER_TITLE_ALIGN_FOR_TRUNCATION,
           // trick to force title ellipsis
           headerBackTitle: ' ',
         })}
@@ -62,7 +63,7 @@ const ItemStackNavigator = () => {
           },
         }) => ({
           title: headerTitle,
-          headerTitleAlign: 'center',
+          headerTitleAlign: HEADER_TITLE_ALIGN_FOR_TRUNCATION,
           // trick to force title ellipsis
           headerBackTitle: ' ',
         })}
@@ -83,7 +84,7 @@ const ItemStackNavigator = () => {
           },
         }) => ({
           title: headerTitle,
-          headerTitleAlign: 'center',
+          headerTitleAlign: HEADER_TITLE_ALIGN_FOR_TRUNCATION,
           // trick to force title ellipsis
           headerBackTitle: ' ',
         })}

--- a/src/navigation/LibraryNavigator.tsx
+++ b/src/navigation/LibraryNavigator.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import { createStackNavigator } from '@react-navigation/stack';
 
+import { HEADER_TITLE_ALIGN_FOR_TRUNCATION } from '../config/constants/constants';
 import { defaultScreenOptions } from '../config/constants/navigation';
 import CollectionScreen from '../screens/library/CollectionScreen';
 import LibraryScreen from '../screens/library/LibraryScreen';
@@ -41,7 +42,7 @@ const LibraryStackNavigator = () => {
           title: '',
           // trick to enable ellipsis for 2 right buttons
           headerBackTitle: ' ',
-          headerTitleAlign: 'center',
+          headerTitleAlign: HEADER_TITLE_ALIGN_FOR_TRUNCATION,
         })}
       />
     </Stack.Navigator>


### PR DESCRIPTION
- fix truncation for android title in app bar: align `center` does not work on android, and the truncation only happens when filling the whole width. On the other hand ios doesn't truncate when using align `left`. So I had to differentiate depending on the platform.
- improving "contains only folders" text
- fix document layout (smaller margins, scroll)